### PR TITLE
feature: How to add runtime codegen to native code like its the 1970s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,140 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "dynasm"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33dc03612f42465a8ed7f5e354bc2b79ba54cedefa81d5bd3a064f1835adaba8"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7dccc31a678058996aef614f6bd418ced384da70f284e83e2b7bf29b27b6a28"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
+]
+
+[[package]]
 name = "eocene"
 version = "0.1.0"
+dependencies = [
+ "dynasm",
+ "dynasmrt",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+dynasm = "2.0.0"
+dynasmrt = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,36 @@
-# Minimally viable query engine with the Volcano model
+# Minimally Viable Query Engine with Interepretation & Runtime Code Generation
 
 This is an implementation of a minimal query engine capable of executing
 a subset of your usual SQL operators by following the Volcano model.
+
+We implement both traditional interpreter and runtime code
+generation based query execution.
+
+For runtime code generation we actually compile to native code directly to x86
+but the query execution can support any backend since we fix the code gen model
+across all of them.
+
+
+## Overview
+
+`eocence` is a demonstration of how a simple query engine can be implemented
+based on the iterator model (non-batched tuples).
+
+In **interpretation** mode we currently support the following operators :
+
+* Scan operator which is the starting point of the pipeline.
+* Projection operator which selects specific columns from each row.
+* Filter operator which runs predicates on rows returning only the ones that satisfy
+  the predicate.
+* Sort operator which returns rows in sorted order.
+* Join operator which implements *Nested Loop Join*.
+* Limit operator which sets a cut-off on the number of returned rows.
+
+When the query execution mode is set to **runtime code generation** then only
+queries that use scans, projections and filters are currently supported with
+the rest left as an exercice to the reader.
+
+## The Volcano Model
 
 The Volcano model often also described as *the classical iterator model* 
 initially described in [Volcano - An Extensible and Parallel Query Evaluation System](https://dl.acm.org/doi/10.1109/69.273032)
@@ -36,25 +65,12 @@ millions of rows, each operator `pull` incurs a function call either via dynamic
 dispatch or through a table using a function pointer which tend to compound when
 you have millions of rows especially when it comes to branch mis-predictions.
 
-# Example
+## Example
 
 The code implements a small query engine with a SQL tokenizer and parser capable
 of representing very simple queries, the AST can then be passed to the query engine
 which will create a query plan in the form of a pipeline of operators before executing
 them.
-
-Please note that the code is not tested, most tests act just as sanity check that
-the base logic is fine. There is no error handling and consideration for edge cases.
-
-We currently implement the following operators :
-
-* Scan operator which is the starting point of the pipeline.
-* Projection operator which selects specific columns from each row.
-* Filter operator which runs predicates on rows returning only the ones that satisfy
-  the predicate.
-* Sort operator which returns rows in sorted order.
-* Join operator which implements *Nested Loop Join*.
-* Limit operator which sets a cut-off on the number of returned rows.
 
 Below is the code in `main.rs` which runs some select queries.
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,4 +1,6 @@
 //! Implementation of runtime code generation for query execution.
+use crate::row::{self, Int64Row};
+use dynasmrt::{aarch64::Assembler, dynasm, AssemblyOffset, DynasmApi, ExecutableBuffer};
 
 /// Index of the column in a row, used as an alias for the column name.
 type ColumnIndex = usize;
@@ -43,6 +45,9 @@ struct QueryPlan {
     pipeline: Vec<Operator>,
 }
 
+#[derive(Debug)]
+struct CompiledQueryPlan(AssemblyOffset, ExecutableBuffer);
+
 impl QueryPlan {
     /// Create a new query plan.
     fn new() -> Self {
@@ -55,32 +60,65 @@ impl QueryPlan {
     fn push(&mut self, operator: Operator) {
         self.pipeline.push(operator)
     }
+}
 
-    /// Compile the query plan to a native code buffer.
-    fn compile(&self) {
-        todo!("Unimplemented query compilation !")
+struct QueryCompiler {
+    plan: QueryPlan,
+    rows: Vec<Int64Row>,
+}
+
+impl QueryCompiler {
+    /// Create a new query compiler.
+    fn new(plan: QueryPlan, rows: Vec<Int64Row>) -> Self {
+        Self { plan, rows }
+    }
+
+    /// Compile the query plan and return a compiled query plan which is a tuple
+    /// of an entry point and executable machine code.
+    fn compile(&self) -> CompiledQueryPlan {
+        // Create a new assembler.
+        let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
+        let mut entry_point = assembler.offset();
+
+        CompiledQueryPlan(entry_point, assembler.finalize().unwrap())
+    }
+
+    /// Compile the `scan` operator.
+    fn scan(&mut self, assembler: &mut Assembler) {
+        let entry_point = assembler.offset();
+
+        // The rows are assumed to be packed, I guess.
+        let row_data = self.rows.as_mut_ptr();
+        let row_count = self.rows.len();
+
+        // Scan is the entry point of the pipeline, which means all downstream
+        // operators end up calling it.
+        dynasm!(assembler
+            ; .arch x64
+            ; push rbp
+            ; mov rbp, rsp
+            ; mov rdi, QWORD row_data as _
+            ; mov rcx, row_count as _
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi, ExecutableBuffer};
+    use dynasmrt::{dynasm, AssemblyOffset, DynasmApi, DynasmLabelApi, ExecutableBuffer};
 
-    pub struct JitCompiler {
-        assembler: dynasmrt::x64::Assembler,
-    }
+    pub struct JitCompiler {}
 
     impl JitCompiler {
         pub fn new() -> Self {
-            JitCompiler {
-                assembler: dynasmrt::x64::Assembler::new().unwrap(),
-            }
+            JitCompiler {}
         }
 
-        pub fn compile_filter(&mut self) -> ExecutableBuffer {
-            let entry_point = self.assembler.offset();
+        pub fn compile_filter(&mut self) -> (AssemblyOffset, ExecutableBuffer) {
+            let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
+            let entry_point = assembler.offset();
 
-            dynasm!(self.assembler
+            dynasm!(assembler
                 ; .arch x64
                 // Prologue: setting up the stack frame
                 ; push rbp
@@ -109,13 +147,13 @@ mod tests {
                 ; ret
             );
 
-            self.assembler.finalize().unwrap()
+            (entry_point, assembler.finalize().unwrap())
         }
     }
-
-    fn main() {
+    #[test]
+    fn can_compile_basic_filter() {
         let mut compiler = JitCompiler::new();
-        let filter_fn = compiler.compile_filter();
+        let (entry_point, filter_fn) = compiler.compile_filter();
 
         let rows = vec![vec![1, 2, 3, 10000], vec![1, 2, 3, 8000]];
 
@@ -126,5 +164,125 @@ mod tests {
             let result = filter(row.as_ptr());
             println!("Row: {:?}, Passed: {}", row, result == 1);
         }
+    }
+}
+
+#[cfg(test)]
+mod scan_tests {
+    use dynasmrt::{dynasm, AssemblyOffset, DynasmApi, DynasmLabelApi, ExecutableBuffer};
+
+    pub struct JitCompiler {
+        row_data: *const i64,
+        row_count: usize,
+    }
+
+    impl JitCompiler {
+        pub fn new(row_data: *const i64, row_count: usize) -> Self {
+            JitCompiler {
+                row_data,
+                row_count,
+            }
+        }
+
+        pub fn compile_project(
+            &mut self,
+            column: usize,
+            data: &mut [i64],
+        ) -> (AssemblyOffset, ExecutableBuffer) {
+            let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
+            let entry_point = assembler.offset();
+            let data_ptr = data.as_ptr();
+            let stride_size = self.row_count / 4;
+            dynasm!(assembler
+                ; .arch x64
+                // Load src vector.
+                ; mov rsi, QWORD self.row_data as _
+                // Load dst vector.
+                ; mov rdi, QWORD data_ptr as _
+                // Initialize index (RCX) to 0
+                ; mov rcx, 0
+                ; ->loop_start:
+                // Compare index with data length
+                ; cmp rcx, stride_size as i64 as i32
+                // If index >= length, exit loop
+                ; jge >exit
+                // Save row index in RBX.
+                // Copy from the projected column from src to dst
+                ; mov rax, [rsi + column as i64 as i32  * 8]
+                ; mov [rdi + rcx * 8], rax
+                // Increment index into `src`.
+                // Increment index into `dst`.
+                ; inc rcx
+                // Repeat.
+                ; jmp ->loop_start
+                ; exit:
+                ; ret
+            );
+
+            let buffer = assembler.finalize().unwrap();
+
+            (entry_point, buffer)
+        }
+
+        pub fn compile_scan(&mut self, data: &mut [i64]) -> (AssemblyOffset, ExecutableBuffer) {
+            let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
+            let entry_point = assembler.offset();
+            let data_ptr = data.as_ptr();
+
+            dynasm!(assembler
+                ; .arch x64
+                ; mov rsi, QWORD self.row_data as _ // Load src vector.
+                ; mov rdi, QWORD data_ptr as _ // Load dst vector.
+                ; mov rcx, 0                                // Initialize index (RSI) to 0
+                ; ->loop_start:
+                ; cmp rcx, self.row_count as i64 as i32       // Compare index with data length
+                ; jge >exit                                 // If index >= length, exit loop
+                ; mov rax, [rsi + rcx * 8]                  // Copy from src to dst
+                ; mov [rdi + rcx * 8], rax
+                 // Here, you can add instructions to process each row
+                ; add rcx, 1                                // Increment index
+                ; jmp ->loop_start                          // Repeat loop
+                ; exit:
+                ; ret                                       // Return from function
+            );
+
+            let buffer = assembler.finalize().unwrap();
+
+            (entry_point, buffer)
+        }
+    }
+
+    #[test]
+    fn can_build_scan_pipeline() {
+        let rows = vec![
+            vec![1, 2, 3, 4000],
+            vec![1, 2, 3, 8000],
+            vec![1, 2, 3, 12000],
+        ];
+
+        // Flatten the rows into a single buffer
+        let flat_rows: Vec<i64> = rows.into_iter().flatten().collect();
+
+        let mut compiler = JitCompiler::new(flat_rows.as_ptr(), flat_rows.len());
+        let mut data = vec![0; flat_rows.len()];
+        let (entry_point, buffer) = compiler.compile_scan(data.as_mut_slice());
+
+        println!("Entry point: {:?}", entry_point);
+
+        // Execute the compiled code
+        let exec_fn: extern "C" fn() -> () =
+            unsafe { std::mem::transmute(buffer.ptr(entry_point)) };
+        exec_fn();
+        println!("Data: {:?}", data);
+
+        let mut data = vec![0; 4];
+        let (entry_point, buffer) = compiler.compile_project(3, data.as_mut_slice());
+
+        println!("Entry point: {:?}", entry_point);
+        // Execute the compiled code
+        let exec_fn: extern "C" fn() -> () =
+            unsafe { std::mem::transmute(buffer.ptr(entry_point)) };
+        exec_fn();
+        println!("Data: {:?}", data)
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,0 +1,130 @@
+//! Implementation of runtime code generation for query execution.
+
+/// Index of the column in a row, used as an alias for the column name.
+type ColumnIndex = usize;
+
+/// Binary operations supported in `WHERE` clauses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BinaryOperator {
+    Equal,
+    GreaterThan,
+    LesserThan,
+}
+
+/// As much as I would like to re-use `sql::Expr` I don't want to deal with
+/// string based comparison, so let's focus on supporting just the subset we
+/// care about, nice 64 bit signed integers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Expr {
+    Column(ColumnIndex),
+    Value(i64),
+    Comparison(BinaryOperator, Box<Expr>, Box<Expr>),
+}
+
+impl Expr {
+    /// Compile an expression to native code.
+    fn compile(&self) {}
+}
+
+/// Operator defines the atoms used to represent query plans that are compiled
+/// to native code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Operator {
+    Project(ColumnIndex),
+    Scan,
+    Filter(Expr),
+}
+
+/// Query plans in the codegen model are very similar to the interpreter based model.
+///
+/// Except that here our operators are not implemented but defined, the implementation
+/// will be the code generated later at runtime.
+struct QueryPlan {
+    pipeline: Vec<Operator>,
+}
+
+impl QueryPlan {
+    /// Create a new query plan.
+    fn new() -> Self {
+        Self { pipeline: vec![] }
+    }
+
+    /// Push a new operator to the plan, in the iterator model the pipeline does not
+    /// create a DAG (I think) so this can be seen as a linear sequence of operators
+    /// where downstream pulls from upstream.
+    fn push(&mut self, operator: Operator) {
+        self.pipeline.push(operator)
+    }
+
+    /// Compile the query plan to a native code buffer.
+    fn compile(&self) {
+        todo!("Unimplemented query compilation !")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi, ExecutableBuffer};
+
+    pub struct JitCompiler {
+        assembler: dynasmrt::x64::Assembler,
+    }
+
+    impl JitCompiler {
+        pub fn new() -> Self {
+            JitCompiler {
+                assembler: dynasmrt::x64::Assembler::new().unwrap(),
+            }
+        }
+
+        pub fn compile_filter(&mut self) -> ExecutableBuffer {
+            let entry_point = self.assembler.offset();
+
+            dynasm!(self.assembler
+                ; .arch x64
+                // Prologue: setting up the stack frame
+                ; push rbp
+                ; mov rbp, rsp
+
+                // Load the salary value from the row (Vec<i64>) into rax
+                ; mov rax, QWORD [rdi + 3 * 8] // rdi holds the pointer to the Vec<i64>, [rdi + 3 * 8] is salary
+
+                // Compare salary with 9000
+                ; cmp rax, 9000
+                // Jump to the `fail` label if the salary is not greater than 9000
+                ; jle >fail
+
+                // Success: return 1 (true)
+                ; mov rax, 1
+                ; jmp >end
+
+                // Fail: return 0 (false)
+                ; fail:
+                ; mov rax, 0
+
+                // Epilogue: restore stack frame and return
+                ; end:
+                ; mov rsp, rbp
+                ; pop rbp
+                ; ret
+            );
+
+            self.assembler.finalize().unwrap()
+        }
+    }
+
+    fn main() {
+        let mut compiler = JitCompiler::new();
+        let filter_fn = compiler.compile_filter();
+
+        let rows = vec![vec![1, 2, 3, 10000], vec![1, 2, 3, 8000]];
+
+        let filter: fn(*const i64) -> i64 =
+            unsafe { std::mem::transmute(filter_fn.ptr(entry_point)) };
+
+        for row in &rows {
+            let result = filter(row.as_ptr());
+            println!("Row: {:?}, Passed: {}", row, result == 1);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod codegen;
 pub mod operators;
 pub mod row;
 pub mod sql;

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,4 +1,4 @@
-//! Implementation of in-memory rows, represented as `Vec<String>`.
+//! Implementation of in-memory generic and simple rows, represented as `Vec<String>`.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Row {
@@ -16,5 +16,28 @@ impl Row {
     /// Returns item at given index.
     pub fn get(&self, index: usize) -> Option<&str> {
         self.items.get(index).map(|x| x.as_str())
+    }
+}
+
+/// Rows that only hold `i64` tuple, because dealing with `String` in inline
+/// assembly might be a pita we just assume all columns are numbers, certainly
+/// all important databases grown up use have `i64`. You woulnd't put a `f64`
+/// in there would you now ?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Int64Row {
+    pub items: Vec<i64>,
+}
+
+impl Int64Row {
+    /// Create a new row from a slice of `i64`.
+    pub fn new(items: &[i64]) -> Self {
+        Self {
+            items: items.to_vec(),
+        }
+    }
+
+    /// Return item at given index without bound checks.
+    pub fn get(&self, index: usize) -> i64 {
+        *self.items.get(index).unwrap()
     }
 }


### PR DESCRIPTION
This PR which is kept here for historical reasons shows a very crude example of doing manual code generation of the basic operators `Project` and `Scan`. This is obviously not functioning since just scaffolding the runtime part to handle actual tuples of data and columns will take a few thousands lines of code, but the concept remains interesting nonetheless.

We switch the Volcano model `next() -> Row` into `next(rows: &mut Row)` where each pull from a downstream operator provides a buffer to the parent operator to fill with the results. This allows us to essentially keep the code very minimal since the final native code can be executed within the same scoped function.

The code generation is not optimal, in fact it's slower than what `gcc -O0` would generate but hey it's a demo !